### PR TITLE
Lazy Loading HTML Image Elements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,15 +121,6 @@ module.exports = function(grunt) {
                 ],
                 commitMessage: 'release %VERSION%'
             }
-        },
-        watch: {
-            scripts: {
-                files: ['src/element-kit.js'],
-                tasks: ['copy', 'uglify'],
-                options: {
-                    spawn: false
-                }
-            }
         }
     });
 
@@ -165,8 +156,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask( "server", [
         "build-files",
-        "connect:local",
-        "watch"
+        "connect:local"
     ]);
 
     grunt.registerTask( "test", [

--- a/docs/image-element.md
+++ b/docs/image-element.md
@@ -1,0 +1,20 @@
+# ImageElement.kit
+
+The following methods will be available to you under the "kit" property of all of your HTMLImageElements (your `<img>` tags).
+
+
+### ImageElement.kit.load
+
+`ImageElement.kit.load(attr)`
+
+Lazy loads an image . `html` is a string of HTML to wrap and append to the parent of the current element.
+
+```javascript
+var el = document.getElementByClassName('div')[0],
+    containerHtml = '<div class="wrapper"></div>',
+    container = el.kit.appendOuterHtml(el, containerHtml);
+
+container.innerHTML
+=>  '<div class="wrapper"><p class="my-existing-content"></p></div>'
+
+```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "grunt-contrib-qunit": "~0.5.2",
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-uglify": "^0.6.0",
-    "grunt-contrib-watch": "^0.6.1",
     "load-grunt-tasks": "0.6.0",
     "phantomjs": "~1.9.7",
     "qunitjs": "1.14.0"

--- a/src/element-kit.js
+++ b/src/element-kit.js
@@ -46,9 +46,9 @@
         return merged;
     }
 
-    var count = 0, cache = {};
+    var elementCount = 0, cache = {}, loaded;
 
-    var Kit = function (el) {
+    var Element = function (el) {
         this.el = el;
         this.classList = this._getClassList();
         this._eventListenerMap = this._eventListenerMap || [];
@@ -63,10 +63,10 @@
     /**
      * A class from which all Elements are based.
      * @description Bootstraps an element to allow for native JS methods (see https://developer.mozilla.org/en-US/docs/Web/API/Element)
-     * @class Kit
+     * @class Element
      * @param {Element} el - The element
      */
-    Kit.prototype = /** @lends Element */{
+    Element.prototype = /** @lends Element */{
 
         /**
          * Wrap a parent container element around the element.
@@ -432,21 +432,63 @@
             this.el.setAttribute('data-' + key, value);
             this._data[key] = value;
 
-        }
+        },
+
+        /**
+         * Destroys the kit on the element.
+         */
+        destroy: function () {}
     };
 
-    Object.defineProperty(Element.prototype, 'kit', {
-        get: function () {
-            if (!cache[this._kitId]) {
-                count++;
-                this._kitId = count;
-                cache[this._kitId] = new Kit(this);
+
+    var ElementKit = function (options) {
+        this.initialize(options);
+    };
+    ElementKit.prototype = {
+        /**
+         * Does a little setup for element kit.
+         */
+        initialize: function (options) {
+
+            var self = this;
+
+            this.options = extend({
+                autoLoad: true
+            }, options);
+
+            // can only define the element property once or an exception will be thrown
+            if (this.options.autoLoad && !loaded) {
+                // load element kit on ALL DOM Elements when they are created
+                loaded = Object.defineProperty(window.Element.prototype, 'kit', {
+                    get: function () {
+                        return self.load(this);
+                    }
+                });
             }
+        },
 
-            return cache[this._kitId];
-        }
-    });
+        /**
+         * Sets up the kit on an element.
+         * @param {HTMLElement} el - The element in which to load the kit onto
+         * @returns {Element} Returns the element instance
+         */
+        load: function (el) {
+            var ElementClass;
+            // only add a new instance of the class if it hasnt already been added
+            if (!cache[el._kitId]) {
+                elementCount++;
+                el._kitId = elementCount;
+                cache[el._kitId] = new Element(el);
+            }
+            return cache[el._kitId];
+        },
+        /**
+         * Destroys element kit.
+         */
+        destroy: function () {}
 
-    return Kit;
+    };
+
+    return ElementKit;
 
 }));

--- a/tests/element-kit-tests.js
+++ b/tests/element-kit-tests.js
@@ -2,7 +2,7 @@ define([
     'sinon',
     'qunit',
     'test-utils',
-    'dist/element-kit'
+    'src/element-kit'
 ], function(
     Sinon,
     QUnit,

--- a/tests/element-kit-tests.js
+++ b/tests/element-kit-tests.js
@@ -1,0 +1,41 @@
+define([
+    'sinon',
+    'qunit',
+    'test-utils',
+    'dist/element-kit'
+], function(
+    Sinon,
+    QUnit,
+    TestUtils,
+    ElementKit
+){
+    "use strict";
+
+    var kit;
+
+    QUnit.module('Kit Tests', {
+        setup: function () {
+            kit = new ElementKit();
+        },
+        teardown: function () {
+            kit.destroy();
+        }
+    });
+
+    QUnit.test('initialization', function() {
+        QUnit.expect(1);
+        var firstEl = document.createElement('div');
+        var secondEl = document.createElement('div');
+        QUnit.notDeepEqual(firstEl.kit, secondEl.kit, 'after kits initialized, each kit has a different instance');
+    });
+
+    QUnit.test('ensuring the same instance is used', function() {
+        QUnit.expect(3);
+        var firstEl = document.createElement('div');
+        QUnit.deepEqual(firstEl, firstEl.kit.el, 'after initializing first el, its kit instance references the first el also');
+        var secondEl = document.createElement('div');
+        QUnit.deepEqual(secondEl, secondEl.kit.el, 'after initialize second el, its kit instance references the second el same el');
+        QUnit.deepEqual(firstEl, firstEl.kit.el, 'first kit\'s el still references the first el');
+    });
+
+});

--- a/tests/element-tests.js
+++ b/tests/element-tests.js
@@ -2,7 +2,7 @@ define([
     'sinon',
     'qunit',
     'test-utils',
-    'dist/element-kit'
+    'src/element-kit'
 ], function(
     Sinon,
     QUnit,

--- a/tests/element-tests.js
+++ b/tests/element-tests.js
@@ -22,22 +22,6 @@ define([
         }
     });
 
-    QUnit.test('initialization', function() {
-        QUnit.expect(1);
-        var firstEl = document.createElement('div');
-        var secondEl = document.createElement('div');
-        QUnit.notDeepEqual(firstEl.kit, secondEl.kit, 'after kits initialized, each kit has a different instance');
-    });
-
-    QUnit.test('ensuring the same instance is used', function() {
-        QUnit.expect(3);
-        var firstEl = document.createElement('div');
-        QUnit.deepEqual(firstEl, firstEl.kit.el, 'after initializing first el, its kit instance references the first el also');
-        var secondEl = document.createElement('div');
-        QUnit.deepEqual(secondEl, secondEl.kit.el, 'after initialize second el, its kit instance references the second el same el');
-        QUnit.deepEqual(firstEl, firstEl.kit.el, 'first kit\'s el still references the first el');
-    });
-
     QUnit.test('adding and removing classes', function() {
         QUnit.expect(3);
         var el = document.createElement('div');

--- a/tests/element-tests.js
+++ b/tests/element-tests.js
@@ -6,11 +6,21 @@ define([
 ], function(
     Sinon,
     QUnit,
-    TestUtils
+    TestUtils,
+    ElementKit
 ){
     "use strict";
 
-    QUnit.module('Element Tests');
+    var kit;
+
+    QUnit.module('Element Tests', {
+        setup: function () {
+            kit = new ElementKit();
+        },
+        teardown: function () {
+            kit.destroy();
+        }
+    });
 
     QUnit.test('initialization', function() {
         QUnit.expect(1);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -17,6 +17,7 @@ require.config({
 
 // require each test
 require([
+    'tests/element-kit-tests',
     'tests/element-tests'
 ], function() {
     QUnit.config.requireExpects = true;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -17,7 +17,7 @@ require.config({
 
 // require each test
 require([
-    'tests/element-kit-tests'
+    'tests/element-tests'
 ], function() {
     QUnit.config.requireExpects = true;
     QUnit.start();


### PR DESCRIPTION
This adds the ability to lazy-load images by specifying an image path in a custom attribute of your `<img>` tag and calling element kits load() method on it.