### PR TITLE
Lazy Loading HTML Image Elements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function(grunt) {
             },
             local: {
                 options: {
-                    options: { livereload: true }
+                    keepalive: true
                 }
             }
         },
@@ -155,7 +155,6 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask( "server", [
-        "build-files",
         "connect:local"
     ]);
 

--- a/src/element-kit.js
+++ b/src/element-kit.js
@@ -463,6 +463,7 @@
             var el = this.el,
                 src = el.getAttribute(srcAttr);
 
+
             this._origSource = this._origSource || el.src; // store original src string
 
             if (!src) {
@@ -474,23 +475,36 @@
                 src = this._getImageSourceSetPath(src);
             }
             this._loadImage(src, callback);
+            this._loadedSrc = src;
             return this;
+        },
+
+        /**
+         * Adds a source path to the src attribute of the image element.
+         * (injects the image into the browser's DOM).
+         */
+        show: function () {
+            if (this._loadedSrc) {
+                this.el.src = this._loadedSrc;
+            } else {
+                console.warn('ElementKit error: show() cannot be called on an image that has not been loaded via load()');
+            }
         },
 
         /**
          * Loads an image in a virtual DOM which will be cached in the browser and shown.
          * @param {string} src - The image source url
          * @param {Function} callback - Function that is called when image has loaded
-         * @returns {ImageElement} Returns the image element
+         * @param {HTMLImageElement} [el] - Optional image element to load the image onto
+         * @returns {string} Returns the image url source
          * @private
          */
-        _loadImage: function (src, callback) {
-            var img = new Image(),
-                el = this.el;
+        _loadImage: function (src, callback, el) {
+            var img = new Image();
+            el = el || document.createElement('img');
             img.onload = callback || function(){};
-            // simply loading the url in src attribute will cache it
             el.src = src;
-            return this;
+            return src;
         },
 
         /**

--- a/src/element-kit.js
+++ b/src/element-kit.js
@@ -49,15 +49,7 @@
     var elementCount = 0, cache = {}, loaded;
 
     var Element = function (el) {
-        this.el = el;
-        this.classList = this._getClassList();
-        this._eventListenerMap = this._eventListenerMap || [];
-
-        Object.defineProperty(this, 'dataset', {
-            get: function () {
-                return this.getData();
-            }.bind(this)
-        })
+        this.initialize(el);
     };
 
     /**
@@ -67,6 +59,18 @@
      * @param {Element} el - The element
      */
     Element.prototype = /** @lends Element */{
+
+        initialize: function (el) {
+            this.el = el;
+            this.classList = this._getClassList();
+            this._eventListenerMap = this._eventListenerMap || [];
+
+            Object.defineProperty(this, 'dataset', {
+                get: function () {
+                    return this.getData();
+                }.bind(this)
+            });
+        },
 
         /**
          * Wrap a parent container element around the element.
@@ -440,6 +444,120 @@
         destroy: function () {}
     };
 
+    /**
+     * A class from which all image elements are based.
+     * @class ImageElement
+     * @param {Element} el - The element
+     * @todo: find a more simple way to extend Element class along with its prototypes
+     */
+    var ImageElement = function (el) {
+        Element.prototype.initialize.call(this, el);
+    };
+    ImageElement.prototype = extend({}, Element.prototype, {
+        /**
+         * Loads the image asset from a provided source url.
+         * @param {string} srcAttr - The attribute on the element which has the image source url
+         * @param {Function} [callback] - The callback fired when the image has loaded
+         */
+        load: function (srcAttr, callback) {
+            var el = this.el,
+                src = el.getAttribute(srcAttr);
+
+            this._origSource = el.src; // store original src string
+
+            if (!src) {
+                console.warn('ElementKit error: ImageElement has no "' + srcAttr + '" attribute to load');
+            }
+
+            if (src.indexOf(',') !== -1) {
+                // image is a srcset!
+                src = this._getImageSourceSetPath(src);
+            }
+            this._loadImage(src, callback);
+            return this;
+        },
+
+        /**
+         * Loads an image in a virtual DOM which will be cached in the browser and shown.
+         * @param {string} src - The image source url
+         * @param {Function} callback - Function that is called when image has loaded
+         * @returns {ImageElement} Returns the image element
+         * @private
+         */
+        _loadImage: function (src, callback) {
+            var img = new Image(),
+                el = this.el;
+            img.onload = callback || function(){};
+            // simply loading the url in src attribute will cache it
+            el.src = src;
+            return this;
+        },
+
+        /**
+         * Gets the original src path before element kit got involved.
+         * @returns {string|*}
+         */
+        getInitialImageSourcePath: function () {
+            return this._origSource;
+        },
+
+        /**
+         * Sniffs srcset attribute and detects the images viewport size to return the correct source image to display
+         * FYI: browsers do have this functionality natively but some of them have it turned by default (Firefox, IE, etc)
+         * @param {string} srcSet - The source set attribute
+         * @returns {string} Returns the source image path
+         * @private
+         */
+        _getImageSourceSetPath: function (srcSet) {
+            var viewportWidth = window.innerWidth,
+                viewportHeight = window.innerHeight,
+                src,
+                widthHeightMap,
+                width,
+                height,
+                found;
+            srcSet.split(',').forEach(function (str) {
+                widthHeightMap = this._buildSourceMapWidthHeight(str);
+                width = widthHeightMap.width || 0;
+                height = widthHeightMap.height || 0;
+                if (!found && viewportWidth >= width && viewportHeight >= height) {
+                    src = str.split(' ')[0];
+                    found = true;
+                }
+            }.bind(this));
+            return src;
+        },
+
+        /**
+         * Builds a mapping of width and height within a srcset attribute.
+         * @param {String} str - The srcset attribute string
+         * @param {Object} [map] - The object that width and height keys will be attached to
+         * @returns {*|{}}
+         * @private
+         */
+        _buildSourceMapWidthHeight: function (str, map) {
+            var frags = str.split(' '),
+                attrId,
+                getNumber = function (frag) {
+                    return Number(frag.substr(0, frag.length - 1))
+                };
+
+            map = map || {};
+
+            frags.shift(); // remove first item since we know it is the filename
+
+            frags.forEach(function (frag) {
+                attrId = frag.charAt(frag.length - 1);
+                if (attrId === 'w') {
+                    map.width = getNumber(frag);
+                } else if (attrId === 'h') {
+                    map.height = getNumber(frag);
+                }
+            });
+            return map;
+        }
+
+    });
 
     var ElementKit = function (options) {
         this.initialize(options);
@@ -461,7 +579,7 @@
                 // load element kit on ALL DOM Elements when they are created
                 loaded = Object.defineProperty(window.Element.prototype, 'kit', {
                     get: function () {
-                        return self.load(this);
+                        return self.setup(this);
                     }
                 });
             }
@@ -470,15 +588,16 @@
         /**
          * Sets up the kit on an element.
          * @param {HTMLElement} el - The element in which to load the kit onto
-         * @returns {Element} Returns the element instance
+         * @returns {Element|ImageElement} Returns the element instance
          */
-        load: function (el) {
+        setup: function (el) {
             var ElementClass;
             // only add a new instance of the class if it hasnt already been added
             if (!cache[el._kitId]) {
+                ElementClass = el instanceof window.HTMLImageElement ? ImageElement : Element;
                 elementCount++;
                 el._kitId = elementCount;
-                cache[el._kitId] = new Element(el);
+                cache[el._kitId] = new ElementClass(el);
             }
             return cache[el._kitId];
         },

--- a/src/element-kit.js
+++ b/src/element-kit.js
@@ -463,7 +463,7 @@
             var el = this.el,
                 src = el.getAttribute(srcAttr);
 
-            this._origSource = el.src; // store original src string
+            this._origSource = this._origSource || el.src; // store original src string
 
             if (!src) {
                 console.warn('ElementKit error: ImageElement has no "' + srcAttr + '" attribute to load');

--- a/tests/image-element-tests.js
+++ b/tests/image-element-tests.js
@@ -2,7 +2,7 @@ define([
     'sinon',
     'qunit',
     'test-utils',
-    'dist/element-kit'
+    'src/element-kit'
 ], function(
     Sinon,
     QUnit,

--- a/tests/image-element-tests.js
+++ b/tests/image-element-tests.js
@@ -1,0 +1,65 @@
+define([
+    'sinon',
+    'qunit',
+    'test-utils',
+    'dist/element-kit'
+], function(
+    Sinon,
+    QUnit,
+    TestUtils,
+    ElementKit
+){
+    "use strict";
+    var kit;
+
+    QUnit.module('Image Element Tests', {
+        setup: function () {
+            kit = new ElementKit();
+        },
+        teardown: function () {
+            kit.destroy();
+        }
+    });
+
+    QUnit.test('lazy loading an image in a custom attribute', function() {
+        QUnit.expect(4);
+        var el = document.createElement('img');
+        var origImage = window.Image;
+        var imageObj = {};
+        window.Image = Sinon.stub().returns(imageObj);
+        el.setAttribute('src', ''); //src should be empty
+        var testImagePath = 'path/to/my/lazy/load/image.jpg';
+        var callbackSpy = Sinon.spy();
+        el.setAttribute('lazy-src', testImagePath);
+        QUnit.equal(el.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
+        el.kit.load('lazy-src', callbackSpy);
+        QUnit.equal(el.getAttribute('src'), testImagePath, 'after calling load(), image src attribute is updated to new lazy load src path');
+        QUnit.equal(callbackSpy.callCount, 0, 'load callback has not yet been fired because image hasnt loaded yet');
+        imageObj.onload(); // trigger image load
+        QUnit.equal(callbackSpy.callCount, 1, 'once image is loaded, callback is fired');
+        window.Image = origImage;
+    });
+
+    QUnit.test('srcset lazy loading', function() {
+        QUnit.expect(4);
+        var el = document.createElement('img');
+        var origImage = window.Image;
+        var imageObj = {};
+        var callbackSpy = Sinon.spy();
+        var testSrcSetPaths = 'medium.jpg 1000w, large.jpg 2000w';
+        var origWindowWidth = window.innerWidth;
+        window.innerWidth = 1200;
+        window.Image = Sinon.stub().returns(imageObj);
+        el.setAttribute('src', ''); //src should be empty
+        el.setAttribute('my-srcset', testSrcSetPaths);
+        QUnit.equal(el.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
+        el.kit.load('my-srcset', callbackSpy);
+        QUnit.equal(el.getAttribute('src'), 'medium.jpg', 'after calling load(), image src attribute was set to medium image because window width fits its requirements');
+        QUnit.equal(callbackSpy.callCount, 0, 'load callback has not yet been fired because image hasnt loaded yet');
+        imageObj.onload(); // trigger image load
+        QUnit.equal(callbackSpy.callCount, 1, 'once image is loaded, callback is fired');
+        window.Image = origImage;
+        window.innerWidth = origWindowWidth;
+    });
+
+});

--- a/tests/image-element-tests.js
+++ b/tests/image-element-tests.js
@@ -22,27 +22,33 @@ define([
     });
 
     QUnit.test('lazy loading an image in a custom attribute', function() {
-        QUnit.expect(4);
-        var el = document.createElement('img');
+        QUnit.expect(5);
+        var DomImageEl = document.createElement('img');
         var origImage = window.Image;
         var imageObj = {};
         window.Image = Sinon.stub().returns(imageObj);
-        el.setAttribute('src', ''); //src should be empty
+        DomImageEl.setAttribute('src', ''); //src should be empty
         var testImagePath = 'path/to/my/lazy/load/image.jpg';
         var callbackSpy = Sinon.spy();
-        el.setAttribute('lazy-src', testImagePath);
-        QUnit.equal(el.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
-        el.kit.load('lazy-src', callbackSpy);
-        QUnit.equal(el.getAttribute('src'), testImagePath, 'after calling load(), image src attribute is updated to new lazy load src path');
+        DomImageEl.setAttribute('lazy-src', testImagePath);
+        var virtualImageEl = {src: ''};
+        var documentCreateElementStub = Sinon.stub(document, 'createElement');
+        documentCreateElementStub.returns(virtualImageEl);
+        DomImageEl.kit.load('lazy-src', callbackSpy);
+        documentCreateElementStub.restore(); // restore document.createElement immediately or suffer
+        QUnit.equal(virtualImageEl.src, testImagePath, 'after calling load(), virtual image src attribute is updated to new lazy load src path to be loaded in virtual memory');
         QUnit.equal(callbackSpy.callCount, 0, 'load callback has not yet been fired because image hasnt loaded yet');
         imageObj.onload(); // trigger image load
         QUnit.equal(callbackSpy.callCount, 1, 'once image is loaded, callback is fired');
+        QUnit.equal(DomImageEl.getAttribute('src'), '', 'DOM image src attribute is still empty because show() has not been called');
+        DomImageEl.kit.show();
+        QUnit.equal(DomImageEl.getAttribute('src'), testImagePath, 'after show() is called, DOM image src attribute has been updated to new path');
         window.Image = origImage;
     });
 
     QUnit.test('srcset lazy loading', function() {
-        QUnit.expect(4);
-        var el = document.createElement('img');
+        QUnit.expect(5);
+        var DomImageEl = document.createElement('img');
         var origImage = window.Image;
         var imageObj = {};
         var callbackSpy = Sinon.spy();
@@ -50,14 +56,22 @@ define([
         var origWindowWidth = window.innerWidth;
         window.innerWidth = 1200;
         window.Image = Sinon.stub().returns(imageObj);
-        el.setAttribute('src', ''); //src should be empty
-        el.setAttribute('my-srcset', testSrcSetPaths);
-        QUnit.equal(el.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
-        el.kit.load('my-srcset', callbackSpy);
-        QUnit.equal(el.getAttribute('src'), 'medium.jpg', 'after calling load(), image src attribute was set to medium image because window width fits its requirements');
+        DomImageEl.setAttribute('src', ''); //src should be empty
+        DomImageEl.setAttribute('my-srcset', testSrcSetPaths);
+        QUnit.equal(DomImageEl.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
+        var virtualImageEl = {src: ''};
+        var documentCreateElementStub = Sinon.stub(document, 'createElement');
+        documentCreateElementStub.returns(virtualImageEl);
+        // test load
+        DomImageEl.kit.load('my-srcset', callbackSpy);
+        documentCreateElementStub.restore(); // restore document.createElement immediately or suffer
+        QUnit.equal(virtualImageEl.src, 'medium.jpg', 'after calling load(), image src attribute was set to medium image because window width fits its requirements');
         QUnit.equal(callbackSpy.callCount, 0, 'load callback has not yet been fired because image hasnt loaded yet');
         imageObj.onload(); // trigger image load
         QUnit.equal(callbackSpy.callCount, 1, 'once image is loaded, callback is fired');
+        // test show
+        DomImageEl.kit.show();
+        QUnit.equal(DomImageEl.getAttribute('src'), 'medium.jpg', 'after show() is called, DOM image src attribute was set to medium image because window width fits its requirements');
         window.Image = origImage;
         window.innerWidth = origWindowWidth;
     });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -18,7 +18,8 @@ require.config({
 // require each test
 require([
     'tests/element-kit-tests',
-    'tests/element-tests'
+    'tests/element-tests',
+    'tests/image-element-tests'
 ], function() {
     QUnit.config.requireExpects = true;
     QUnit.start();


### PR DESCRIPTION
This adds the ability to lazy-load images by specifying an image path in a custom attribute of your `<img>` tag and calling element kits load() method on it.