### PR TITLE
Consolidating ImageElement.show() + ImageElement.load()

### DIFF
--- a/src/element-kit.js
+++ b/src/element-kit.js
@@ -489,8 +489,6 @@
             var el = this.el,
                 src = el.getAttribute(srcAttr);
 
-            this._origSource = this._origSource || el.src; // store original src string
-
             if (!src) {
                 console.warn('ElementKit error: ImageElement has no "' + srcAttr + '" attribute to load');
             }
@@ -500,18 +498,7 @@
                 src = this._getImageSourceSetPath(src);
             }
             this._loadImage(src, callback);
-            this._loadedSrc = src;
             return this;
-        },
-
-        /**
-         * Adds a source path to the src attribute of the image element.
-         * (injects the image into the browser's DOM).
-         */
-        show: function () {
-            if (this._loadedSrc) {
-                this.el.src = this._loadedSrc;
-            }
         },
 
         /**
@@ -522,20 +509,11 @@
          * @returns {string} Returns the image url source
          * @private
          */
-        _loadImage: function (src, callback, el) {
+        _loadImage: function (src, callback) {
             var img = new Image();
-            el = el || document.createElement('img');
             img.onload = callback || function(){};
-            el.src = src;
+            this.el.src = src;
             return src;
-        },
-
-        /**
-         * Gets the original src path before element kit got involved.
-         * @returns {string|*}
-         */
-        getInitialImageSourcePath: function () {
-            return this._origSource;
         },
 
         /**

--- a/tests/image-element-tests.js
+++ b/tests/image-element-tests.js
@@ -14,33 +14,26 @@ define([
     QUnit.module('Image Element Tests');
 
     QUnit.test('lazy loading an image in a custom attribute', function() {
-        QUnit.expect(5);
-        var DomImageEl = document.createElement('img');
+        QUnit.expect(3);
+        var imageEl = document.createElement('img');
         var origImage = window.Image;
         var imageObj = {};
         window.Image = Sinon.stub().returns(imageObj);
-        DomImageEl.setAttribute('src', ''); //src should be empty
+        imageEl.setAttribute('src', ''); //src should be empty initially
         var testImagePath = 'path/to/my/lazy/load/image.jpg';
         var callbackSpy = Sinon.spy();
-        DomImageEl.setAttribute('lazy-src', testImagePath);
-        var virtualImageEl = {src: ''};
-        var documentCreateElementStub = Sinon.stub(document, 'createElement');
-        documentCreateElementStub.returns(virtualImageEl);
-        DomImageEl.kit.load('lazy-src', callbackSpy);
-        documentCreateElementStub.restore(); // restore document.createElement immediately or suffer
-        QUnit.equal(virtualImageEl.src, testImagePath, 'after calling load(), virtual image src attribute is updated to new lazy load src path to be loaded in virtual memory');
+        imageEl.setAttribute('lazy-src', testImagePath);
+        imageEl.kit.load('lazy-src', callbackSpy);
+        QUnit.equal(imageEl.getAttribute('src'), testImagePath, 'after calling load(), DOM image src attribute has been updated to new path');
         QUnit.equal(callbackSpy.callCount, 0, 'load callback has not yet been fired because image hasnt loaded yet');
         imageObj.onload(); // trigger image load
         QUnit.equal(callbackSpy.callCount, 1, 'once image is loaded, callback is fired');
-        QUnit.equal(DomImageEl.getAttribute('src'), '', 'DOM image src attribute is still empty because show() has not been called');
-        DomImageEl.kit.show();
-        QUnit.equal(DomImageEl.getAttribute('src'), testImagePath, 'after show() is called, DOM image src attribute has been updated to new path');
         window.Image = origImage;
     });
 
     QUnit.test('srcset lazy loading', function() {
-        QUnit.expect(5);
-        var DomImageEl = document.createElement('img');
+        QUnit.expect(4);
+        var imageEl = document.createElement('img');
         var origImage = window.Image;
         var imageObj = {};
         var callbackSpy = Sinon.spy();
@@ -48,22 +41,15 @@ define([
         var origWindowWidth = window.innerWidth;
         window.innerWidth = 1200;
         window.Image = Sinon.stub().returns(imageObj);
-        DomImageEl.setAttribute('src', ''); //src should be empty
-        DomImageEl.setAttribute('my-srcset', testSrcSetPaths);
-        QUnit.equal(DomImageEl.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
-        var virtualImageEl = {src: ''};
-        var documentCreateElementStub = Sinon.stub(document, 'createElement');
-        documentCreateElementStub.returns(virtualImageEl);
+        imageEl.setAttribute('src', ''); //src should be empty initially
+        imageEl.setAttribute('my-srcset', testSrcSetPaths);
+        QUnit.equal(imageEl.getAttribute('src'), '', 'image src attribute is still empty because load() has not been called');
         // test load
-        DomImageEl.kit.load('my-srcset', callbackSpy);
-        documentCreateElementStub.restore(); // restore document.createElement immediately or suffer
-        QUnit.equal(virtualImageEl.src, 'medium.jpg', 'after calling load(), image src attribute was set to medium image because window width fits its requirements');
+        imageEl.kit.load('my-srcset', callbackSpy);
+        QUnit.equal(imageEl.getAttribute('src'), 'medium.jpg', 'after calling load(), image src attribute was set to medium image because window width fits its requirements');
         QUnit.equal(callbackSpy.callCount, 0, 'load callback has not yet been fired because image hasnt loaded yet');
         imageObj.onload(); // trigger image load
         QUnit.equal(callbackSpy.callCount, 1, 'once image is loaded, callback is fired');
-        // test show
-        DomImageEl.kit.show();
-        QUnit.equal(DomImageEl.getAttribute('src'), 'medium.jpg', 'after show() is called, DOM image src attribute was set to medium image because window width fits its requirements');
         window.Image = origImage;
         window.innerWidth = origWindowWidth;
     });


### PR DESCRIPTION
Removing show() method, load() already handles this. Doing so, allowed removing unnecessary internal management of the attribute states. Simpler logic is better. Updated unit tests.