### PR TITLE
New scrollIntoView() method

### DIFF
--- a/src/element-kit.js
+++ b/src/element-kit.js
@@ -71,6 +71,13 @@
         },
 
         /**
+         * Causes the browser to scroll until the element is in view.
+         */
+        scrollIntoView: function () {
+            window.scrollTo(0, this.getWindowOffsetTop());
+        },
+
+        /**
          * Returns the distance of the element relative to the top of the window/document.
          * @returns {Number|undefined}
          */

--- a/tests/element-tests.js
+++ b/tests/element-tests.js
@@ -322,4 +322,29 @@ define([
         document.body.removeChild(firstEl);
     });
 
+    QUnit.test('scrolling an element into view', function() {
+        QUnit.expect(1);
+        var windowScrollToStub = Sinon.stub(window, 'scrollTo');
+
+        var firstEl = document.createElement('div');
+        firstEl.style.position = 'absolute';
+        firstEl.style.top = '0';
+        firstEl.style.left = '0';
+        firstEl.style.paddingTop = '20px';
+        firstEl.style.marginTop = '40px';
+        var secondEl = document.createElement('div');
+        secondEl.style.paddingTop = '20px';
+        var thirdEl = document.createElement('div');
+        thirdEl.style.paddingTop = '20px';
+        // append nodes
+        secondEl.appendChild(thirdEl);
+        firstEl.appendChild(secondEl);
+        document.body.appendChild(firstEl);
+        thirdEl.kit.scrollIntoView();
+        QUnit.deepEqual(windowScrollToStub.args[0], [0, 100], 'calling scrollIntoView() on third nested element calls window.scrollTo with correct args');
+        document.body.removeChild(firstEl);
+
+        windowScrollToStub.restore();
+    });
+
 });


### PR DESCRIPTION
Adds a new `scrollIntoView()` method that, when called, will scroll the browser viewport down until the element is in view (aligned to the top). 