### PR TITLE
IE image error fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "tests"
   ],
   "dependencies": {
-    "promise": "~0.2.2"
+    "promise": "~0.2.2",
+    "string": "~3.1.1"
   }
 }

--- a/src/image-element.js
+++ b/src/image-element.js
@@ -42,12 +42,16 @@ ImageElement.prototype = utils.extend({}, Element.prototype, {
      */
     _loadImage: function (src) {
         var img = this.el;
-        return new Promise(function (resolve, reject) {
+        return new Promise(function (resolve) {
             img.onload = function () {
                 resolve(img);
             };
             img.onerror = function () {
-                reject(new Error('ImageElement error: image path "' + src + '" returned an error'));
+                // IE 9-11 have an issue where it automatically triggers an error on some images,
+                // and then will immediately trigger onload() causing intermittent errors to appear
+                // until this is fixed or we have a workaround, we will be resolving
+                // even if there is an error
+                resolve(img);
             };
             img.src = src;
         });


### PR DESCRIPTION
Removing error triggering for images for now until a solution can be determined for latest versions of IE